### PR TITLE
Object and control tests

### DIFF
--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -1,9 +1,8 @@
-import { BinaryOperationVertex, BinaryOperation, ReturnVertex, VertexKind, Value, ControlVertex, LiteralVertex, DataVertex } from 'graphir';
-import { State } from './state'
+import { BinaryOperationVertex, BinaryOperation, VertexKind, Value, LiteralVertex, DataVertex } from 'graphir';
+import { State, DataVariant } from './state'
 
-
-export function evaluateDataNode(state: State, node: DataVertex): Value {
-    let value: Value = 0;
+export function evaluateDataNode(state: State, node: DataVertex): DataVariant {
+    let value: DataVariant;
 
     switch (node.kind) {
         case VertexKind.Literal:
@@ -14,14 +13,28 @@ export function evaluateDataNode(state: State, node: DataVertex): Value {
             value = evaluateBinaryNode(state, node as BinaryOperationVertex);
             return value;
 
+        case VertexKind.Allocation:
+            if (state.vertexExists(node.id) ==  false) {
+                throw new Error(`Allocation vertex's value does not exist in the program state`);
+            }
+            value = state.getVertexData(node);
+            return value;
+
+        case VertexKind.Load:
+            if (state.vertexExists(node.id) ==  false) {
+                throw new Error(`Load vertex's value does not exist in the program state`);
+            }
+            value = state.getVertexData(node);
+            return value;
+
         default:
             throw new Error(`Data node kind invalid or not implemented`);
     }
 }
 
-export function evaluateBinaryNode(state: State, node: BinaryOperationVertex): Value {
-    let leftValue: Value = evaluateDataNode(state, node.left!);
-    let rightValue: Value = evaluateDataNode(state, node.right!);
+function evaluateBinaryNode(state: State, node: BinaryOperationVertex): Value {
+    let leftValue: Value = evaluateDataNode(state, node.left!) as Value;
+    let rightValue: Value = evaluateDataNode(state, node.right!) as Value;
 
     if ((typeof leftValue === "number") && (typeof rightValue === "number")) {
         switch (node.operator) {

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,14 +1,66 @@
-import { ReturnVertex, VertexKind, Value, ControlVertex, DataVertex, BranchVertex } from 'graphir';
-import { State } from './state'
+import { ReturnVertex, VertexKind, ControlVertex, DataVertex, StoreVertex, LoadVertex } from 'graphir';
+import { State, VertexId, DataVariant, Property } from './state'
 import * as evaluate from './evaluate'
 
 export function executeControlNode(state: State, node: ControlVertex) {
     switch (node.kind) {
         case VertexKind.Return:
-            let returnedValue: Value =  evaluate.evaluateDataNode(state, (<ReturnVertex>node).value as DataVertex);
+            let returnedValue: DataVariant =  evaluate.evaluateDataNode(state, (<ReturnVertex>node).value as DataVertex);
             state.setReturnedValue(returnedValue);
             break;
+
+        case VertexKind.Pass:
+            break;
+
+        case VertexKind.Allocation:
+            state.setVertexData(node, {});
+            break;
+
+        case VertexKind.Store:
+            executeStoreNode(state, node as StoreVertex);
+            break;
+
+        case VertexKind.Load:
+            executeLoadNode(state, node as LoadVertex);
+            break;
+
         default:
             throw new Error(`Control node kind invalid or not implemented`);
     }
+}
+
+function executeStoreNode(state: State, node: StoreVertex) {
+    // get the object vertex's id
+    let objectId: VertexId = node.object?.id as VertexId;
+    if (state.vertexExists(objectId) ==  false) {
+        throw new Error(`Store vertex's object vertex does not exist in the program state`);
+    }
+
+    // get the property's name
+    let propertyVertex: DataVertex = node.property as DataVertex;
+    let property: Property = evaluate.evaluateDataNode(state, propertyVertex) as string;
+
+    // get the value
+    let valueVertex: DataVertex = node.value as DataVertex;
+    let value: DataVariant = evaluate.evaluateDataNode(state, valueVertex);
+
+    // store the value in the program state
+    state.setObjectField(objectId, property, value);
+}
+
+function executeLoadNode(state: State, node: LoadVertex) {
+    // get the object vertex's id
+    let objectId: VertexId = node.object?.id as VertexId;
+    if (state.vertexExists(objectId) ==  false) {
+        throw new Error(`Load vertex's object vertex does not exist in the program state`);
+    }
+
+    // get the property's name
+    let propertyVertex: DataVertex = node.property as DataVertex;
+    let property: Property = evaluate.evaluateDataNode(state, propertyVertex) as string;
+
+    // load the value from the program state
+    let value: DataVariant = state.getObjectField(objectId, property);
+
+    state.setVertexData(node, value);
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1,5 +1,5 @@
 
-import { Graph, Vertex, NonTerminalControlVertex, ControlVertex } from 'graphir';
+import { Graph, Vertex, NonTerminalControlVertex, ControlVertex, VertexKind } from 'graphir';
 import { State } from './state'
 import * as execute from './execute'
 
@@ -26,11 +26,20 @@ export function executeGraph(graph: Graph): ExecutionResult {
     }
     
     let state = new State();
-    let currentNode: NonTerminalControlVertex = graph.getStartVertex().next!;
+    let currentNode: ControlVertex = graph.getStartVertex().next!;
 
     while (currentNode !== undefined) {
         execute.executeControlNode(state, currentNode);
-        currentNode = currentNode.next as ControlVertex;
+
+        if (currentNode instanceof NonTerminalControlVertex) {
+            currentNode = currentNode.next as ControlVertex;
+        }
+        else if (currentNode.kind == VertexKind.Return) {
+            break;
+        }
+        else {
+            throw new Error(`Reached a branch vertex - not implemented`);
+        }
     }
 
     return new ExecutionResult(state);

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -12,7 +12,10 @@ export class ExecutionResult {
     }
 
     queryVertexValue(vertex: Vertex): unknown {
-        return this._finalState.getVertexValue(vertex);
+        if (this._finalState.vertexExists(vertex.id) ==  false) {
+            throw new Error(`Vertex value does not exist in the program final state`);
+        }
+        return this._finalState.getVertexData(vertex);
     }
 
     returnValue(): unknown {

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,37 +1,44 @@
 import assert from 'assert';
 import { Value, Vertex, VertexKind } from 'graphir';
 
+export type VertexId = number;
+export type Property = string;
+export type ObjectFields = { [key: Property]: DataVariant }
+export type DataVariant = Value | ObjectFields;
+
 export class State {
     
-    private _verticesValuesMap: Map<number, Value>;
-    private _returnedValue: Value = 0; // assumption: the program always returns a value
+    private _verticesValuesMap: { [key: VertexId]: DataVariant } = {};
+    private _returnedValue: DataVariant = 0; // assumption: the program always returns a value
 
-    constructor() {
-        this._verticesValuesMap = new Map<number, Value>();
-    }
-
-    setVertexValue(vertex: Vertex, value: Value) {
+    setVertexData(vertex: Vertex, value: DataVariant) {
         assert(this.isStateful(vertex.kind));
-        this._verticesValuesMap.set(vertex.id, value);
+        this._verticesValuesMap[vertex.id] = value;
     }
 
-    getVertexValue(vertex: Vertex): Value {
-        assert(this.isStateful(vertex.kind));
-        if (this._verticesValuesMap.has(vertex.id) == false) {
-            throw new Error(`Vertex id ${vertex.id} value doesn't exist in the program state`);
-        }
-        return this._verticesValuesMap.get(vertex.id) as Value;
+    getVertexData(vertex: Vertex): DataVariant {
+        return this._verticesValuesMap[vertex.id] as DataVariant;
     }
 
-    vertexValueExists(id: number): boolean {
-        return (this._verticesValuesMap.has(id) == true);
+    vertexExists(id: VertexId): boolean {
+        return (id in this._verticesValuesMap);
     }
 
-    setReturnedValue(returnedValue: Value) {
+    setObjectField(id: VertexId, property: Property, fieldValue: DataVariant) {
+        let objectFields: ObjectFields = this._verticesValuesMap[id] as ObjectFields;
+        objectFields[property] = fieldValue;
+    }
+
+    getObjectField(id: VertexId, property: Property): DataVariant {
+        let objectFields: ObjectFields = this._verticesValuesMap[id] as ObjectFields;
+        return objectFields[property];
+    }
+
+    setReturnedValue(returnedValue: DataVariant) {
         this._returnedValue = returnedValue;
     }
 
-    getReturnedValue(): Value {
+    getReturnedValue(): DataVariant {
         return this._returnedValue;
     }
 


### PR DESCRIPTION
2 tests pass:
1. basic_object_operation.test
2. basic_control_flow.test
The program state map can now hold also vertices with object as a value.
Allocation, store and load vertices can be executed as control nodes. Allocation and load vertices can be evaluated as data nodes.